### PR TITLE
Fix library binding on Linux

### DIFF
--- a/pyflann/__init__.py
+++ b/pyflann/__init__.py
@@ -24,6 +24,8 @@
 #(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 #THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+__version__ = '1.6.13'
+
 from index import *
 from io.dataset import load, save
 try:

--- a/pyflann/bindings/flann_ctypes.py
+++ b/pyflann/bindings/flann_ctypes.py
@@ -133,7 +133,7 @@ def load_flann_library():
 
     root_dir = os.path.abspath(os.path.dirname(__file__))
 
-    libnames = ['linux/libflann.so']
+    libnames = ['linux/libflann.so', 'libflann.so']
     libdir = 'lib'
     if sys.platform == 'win32':
         if sys.maxsize > 2 ** 32:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pyflann',
-    version='1.6.12',
+    version='1.6.13',
     description='pyflann is the python bindings for FLANN - Fast Library for Approximate Nearest Neighbors.',
     author='Marius Muja & Gefu Tang',
     author_email='mariusm@cs.ubc.ca, tanggefu@gmail.com',


### PR DESCRIPTION
By default, FLANN will install into `⁠⁠⁠⁠/usr/local/libflann.so`,
however pyflann searches for`linux/libflann.so` and never finds
it. This patch fixes the behavior by also making pyflann look
for `libflann.so`
